### PR TITLE
implement classpath resolver crate with kotlin workspace detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "classpath_resolver"
+version = "0.0.1"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ tokenizer = { path = "./crates/tokenizer" }
 tokens = { path = "./libs/tokens" }
 token_maps = { path = "./libs/token_maps" }
 macros = { path = "./libs/macros" }
+classpath_resolver = { path = "./libs/classpath_resolver" }

--- a/crates/tokenizer/src/lexers.rs
+++ b/crates/tokenizer/src/lexers.rs
@@ -30,14 +30,10 @@ trait ParseFn<'a>: Fn(Step<'a>) -> Option<Step<'a>> {
 
 impl<'a, F> ParseFn<'a> for F where F: Fn(Step<'a>) -> Option<Step<'a>> {}
 
-/**
-    This type represents the span of a token.
-*/
+/// This type represents the span of a token.
 pub type Span = Range<usize>;
 
-/**
-    This type contains information about a token including its kind and span.
-*/
+/// This type contains information about a token including its kind and span.
 #[derive(Debug, Clone)]
 pub struct TokenInfo {
     kind: TokenKind,
@@ -59,12 +55,10 @@ impl Display for TokenInfo {
     }
 }
 
-/**
-    This represents the grammar mode of the lexer. The three states are:
-    - Normal: The default mode for all non string tokens in the syntax
-    - String: The mode for single line string literals
-    - MultilineString: The mode for multiline string literals
-*/
+/// This represents the grammar mode of the lexer. The three states are:
+/// - Normal: The default mode for all non string tokens in the syntax
+/// - String: The mode for single line string literals
+/// - MultilineString: The mode for multiline string literals
 #[derive(Debug, Clone, PartialEq)]
 pub enum LexGrammarMode {
     Normal,
@@ -72,9 +66,7 @@ pub enum LexGrammarMode {
     MultilineString,
 }
 
-/**
-    This is the main lexer that contains the input string and the current position.
-*/
+/// This is the main lexer that contains the input string and the current position.
 #[derive(Debug, Clone)]
 pub struct Lexer<'a> {
     input: &'a str,
@@ -84,10 +76,8 @@ pub struct Lexer<'a> {
     token: TokenKind,
 }
 
-/**
-    This is a single step in the lexer that contains the current position,
-    the result of the tokenization, the current mode and the previous mode.
-*/
+/// This is a single step in the lexer that contains the current position,
+/// the result of the tokenization, the current mode and the previous mode.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Step<'a> {
     pos: usize,
@@ -149,9 +139,7 @@ impl<'a> Step<'a> {
     }
 }
 
-/**
-    This is an enum that represents the kind of token that is being processed.
-*/
+/// This is an enum that represents the kind of token that is being processed.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TokenKind {
     Operator(Token),
@@ -229,9 +217,7 @@ impl<'a> Lexer<'a> {
         self.mode = step.mode.clone();
     }
 
-    /**
-        This method returns an iterator over the tokens in the input string.
-    */
+    /// This method returns an iterator over the tokens in the input string.
     pub fn spanned(self) -> impl Iterator<Item = TokenInfo> + 'a {
         self.scan(0, |start, step| {
             let next = TokenInfo {
@@ -406,7 +392,7 @@ fn handle_operator<'a>(mut step: Step<'a>, token: &Token) -> Option<Step<'a>> {
             Some(step)
         }
         Token::TripleQuoteOpen => {
-            step.set_mode(LexGrammarMode::MultilineString);
+            step.mode = LexGrammarMode::MultilineString;
             Some(step)
         }
         Token::ExclNoWs => opt(hidden.with(TokenKind::Operator(Token::ExclWs)))(step),
@@ -638,10 +624,8 @@ fn when<'a>(condition: impl Fn(char) -> bool) -> impl ParseFn<'a> {
     }
 }
 
-/**
-    This matches multiple entities of the same type one or more times.
-    For zero or more times, use `many0`
-*/
+/// This matches multiple entities of the same type one or more times.
+/// For zero or more times, use `many0`
 #[inline]
 fn many<'a>(p: impl ParseFn<'a>) -> impl ParseFn<'a> {
     move |step| {
@@ -661,10 +645,8 @@ fn many<'a>(p: impl ParseFn<'a>) -> impl ParseFn<'a> {
     }
 }
 
-/**
-    This matches multiple entities of the same type zero or more times.
-    For one or more times, use `many`
-*/
+/// This matches multiple entities of the same type zero or more times.
+/// For one or more times, use `many`
 #[inline]
 fn many0<'a>(p: impl ParseFn<'a>) -> impl ParseFn<'a> {
     opt(many(p))

--- a/crates/tokenizer/src/lexers.rs
+++ b/crates/tokenizer/src/lexers.rs
@@ -30,8 +30,14 @@ trait ParseFn<'a>: Fn(Step<'a>) -> Option<Step<'a>> {
 
 impl<'a, F> ParseFn<'a> for F where F: Fn(Step<'a>) -> Option<Step<'a>> {}
 
+/**
+    This type represents the span of a token.
+*/
 pub type Span = Range<usize>;
 
+/**
+    This type contains information about a token including its kind and span.
+*/
 #[derive(Debug, Clone)]
 pub struct TokenInfo {
     kind: TokenKind,
@@ -53,6 +59,12 @@ impl Display for TokenInfo {
     }
 }
 
+/**
+    This represents the grammar mode of the lexer. The three states are:
+    - Normal: The default mode for all non string tokens in the syntax
+    - String: The mode for single line string literals
+    - MultilineString: The mode for multiline string literals
+*/
 #[derive(Debug, Clone, PartialEq)]
 pub enum LexGrammarMode {
     Normal,
@@ -60,6 +72,9 @@ pub enum LexGrammarMode {
     MultilineString,
 }
 
+/**
+    This is the main lexer that contains the input string and the current position.
+*/
 #[derive(Debug, Clone)]
 pub struct Lexer<'a> {
     input: &'a str,
@@ -69,6 +84,10 @@ pub struct Lexer<'a> {
     token: TokenKind,
 }
 
+/**
+    This is a single step in the lexer that contains the current position,
+    the result of the tokenization, the current mode and the previous mode.
+*/
 #[derive(Debug, Clone, PartialEq)]
 pub struct Step<'a> {
     pos: usize,
@@ -130,6 +149,9 @@ impl<'a> Step<'a> {
     }
 }
 
+/**
+    This is an enum that represents the kind of token that is being processed.
+*/
 #[derive(Debug, Clone, PartialEq)]
 pub enum TokenKind {
     Operator(Token),
@@ -207,6 +229,9 @@ impl<'a> Lexer<'a> {
         self.mode = step.mode.clone();
     }
 
+    /**
+        This method returns an iterator over the tokens in the input string.
+    */
     pub fn spanned(self) -> impl Iterator<Item = TokenInfo> + 'a {
         self.scan(0, |start, step| {
             let next = TokenInfo {
@@ -381,7 +406,7 @@ fn handle_operator<'a>(mut step: Step<'a>, token: &Token) -> Option<Step<'a>> {
             Some(step)
         }
         Token::TripleQuoteOpen => {
-            step.mode = LexGrammarMode::MultilineString;
+            step.set_mode(LexGrammarMode::MultilineString);
             Some(step)
         }
         Token::ExclNoWs => opt(hidden.with(TokenKind::Operator(Token::ExclWs)))(step),
@@ -613,8 +638,10 @@ fn when<'a>(condition: impl Fn(char) -> bool) -> impl ParseFn<'a> {
     }
 }
 
-/// This matches one or more p
-/// Looking to match at zero or more, use `many0`
+/**
+    This matches multiple entities of the same type one or more times.
+    For zero or more times, use `many0`
+*/
 #[inline]
 fn many<'a>(p: impl ParseFn<'a>) -> impl ParseFn<'a> {
     move |step| {
@@ -634,8 +661,10 @@ fn many<'a>(p: impl ParseFn<'a>) -> impl ParseFn<'a> {
     }
 }
 
-/// This matches zero or more p.
-/// Looking to match atleast one, use `many`
+/**
+    This matches multiple entities of the same type zero or more times.
+    For one or more times, use `many`
+*/
 #[inline]
 fn many0<'a>(p: impl ParseFn<'a>) -> impl ParseFn<'a> {
     opt(many(p))
@@ -892,7 +921,7 @@ mod test {
         """
         """
         complex ${ref}
-        "line string iniside multi"
+        "line string inside multi"
         """"""
         """""""""" // open with three, 4 quotes inside and 3 closing
         "#;

--- a/libs/classpath_resolver/Cargo.toml
+++ b/libs/classpath_resolver/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "classpath_resolver"
+version = "0.0.1"
+description = "Resolves the classpath for a Kotlin project"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true

--- a/libs/classpath_resolver/classpath.gradle
+++ b/libs/classpath_resolver/classpath.gradle
@@ -1,0 +1,78 @@
+allprojects { project ->
+    task classpaths { task ->
+        doLast {
+            System.out.println ""
+            System.out.println "gradle-version $gradleVersion"
+            System.out.println "project-name ${project.name}"
+
+            if (project.hasProperty('android')) {
+                project.android.getBootClasspath().each {
+                    System.out.println "gradle-classpath-resolver $it"
+                }
+
+                def variants = []
+
+                if (project.android.hasProperty('applicationVariants')) {
+                    variants += project.android.applicationVariants
+                }
+
+                if (project.android.hasProperty('libraryVariants')) {
+                    variants += project.android.libraryVariants
+                }
+
+                variants.each { variant ->
+                    def variantBase = variant.baseName.replaceAll("-", File.separator)
+
+                    def buildClasses = project.getBuildDir().absolutePath +
+                        File.separator + "intermediates" +
+                        File.separator + variantBase +
+                        File.separator + "classes"
+
+                    System.out.println "gradle-classpath-resolver $buildClasses"
+
+                    def userClasses = project.getBuildDir().absolutePath +
+                        File.separator + "intermediates" +
+                        File.separator + "javac" +
+                        File.separator + variantBase +
+                        File.separator + "compile" + variantBase.capitalize() + "JavaWithJavac" + File.separator + "classes"
+
+                    System.out.println "gradle-classpath-resolver $userClasses"
+
+                    def userVariantClasses = project.getBuildDir().absolutePath +
+                        File.separator + "intermediates" +
+                        File.separator + "javac" +
+                        File.separator + variantBase +
+                        File.separator + "classes"
+
+                    System.out.println "gradle-classpath-resolver $userVariantClasses"
+
+                    variant.getCompileClasspath().each {
+                        System.out.println "gradle-classpath-resolver $it"
+                    }
+                }
+            } else if (project.hasProperty('sourceSets')) {
+                // Print the list of all dependencies jar files.
+                sourceSets.forEach {
+                    it.compileClasspath.forEach {
+                        System.out.println "gradle-classpath-resolver $it"
+                    }
+                }
+            }
+
+
+            // handle kotlin multiplatform style dependencies if any
+            def kotlinExtension = project.extensions.findByName("kotlin")
+            if(kotlinExtension && kotlinExtension.hasProperty("targets")) {
+                def kotlinSourceSets = kotlinExtension.sourceSets
+
+                // Print the list of all dependencies jar files.
+                kotlinExtension.targets.names.each {
+                    def classpath = configurations["${it}CompileClasspath"]
+                    classpath.files.each {
+                        System.out.println "gradle-classpath-resolver $it"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/libs/classpath_resolver/src/lib.rs
+++ b/libs/classpath_resolver/src/lib.rs
@@ -1,0 +1,3 @@
+mod resolver;
+
+pub use resolver::*;

--- a/libs/classpath_resolver/src/resolver.rs
+++ b/libs/classpath_resolver/src/resolver.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum WorkspaceType {
+    Maven,
+    Gradle,
+}
+
+pub struct ClasspathResolver {
+    workspace_type: Option<WorkspaceType>,
+    workspace_root: PathBuf,
+    classpath: Vec<PathBuf>,
+}
+
+impl ClasspathResolver {
+    pub fn new_with_type(
+        workspace_root: PathBuf,
+        workspace_type: Option<WorkspaceType>,
+    ) -> ClasspathResolver {
+        let classpath = match workspace_type {
+            Some(WorkspaceType::Maven) => resolve_maven_classpath(&workspace_root),
+            Some(WorkspaceType::Gradle) => resolve_gradle_classpath(&workspace_root),
+            None => vec![],
+        };
+
+        ClasspathResolver {
+            workspace_type,
+            workspace_root,
+            classpath,
+        }
+    }
+
+    pub fn new(workspace_root: PathBuf) -> ClasspathResolver {
+        let workspace_type = detect_workspace_type(&workspace_root);
+
+        ClasspathResolver::new_with_type(workspace_root, workspace_type)
+    }
+}
+
+fn detect_workspace_type(workspace_root: &PathBuf) -> Option<WorkspaceType> {
+    if workspace_root.join("pom.xml").exists() {
+        return Some(WorkspaceType::Maven);
+    } else if workspace_root.join("build.gradle").exists()
+        || workspace_root.join("build.gradle.kts").exists()
+    {
+        return Some(WorkspaceType::Gradle);
+    }
+
+    None
+}
+
+fn resolve_maven_classpath(workspace_root: &PathBuf) -> Vec<PathBuf> {
+    // Resolve the classpath for a Maven workspace
+    vec![]
+}
+
+fn resolve_gradle_classpath(workspace_root: &PathBuf) -> Vec<PathBuf> {
+    // Resolve the classpath for a Gradle workspace
+    vec![]
+}


### PR DESCRIPTION
This creates a new crate called `classpath_resolver`. The plan for this crate is to serve as a way to resolve the classpath for the project regardless of workspace type (maven/gradle).

Right now the actual functions for generating the classpath are just stubs. There is a function to detect the workspace type.

close #6 , close #7 